### PR TITLE
Remove check for method_exists($model, $relationKey)

### DIFF
--- a/src/EarthlingInteractive/JsonApi/Handler.php
+++ b/src/EarthlingInteractive/JsonApi/Handler.php
@@ -282,13 +282,9 @@ abstract class Handler
      */
     protected static function getModelsForRelation($model, $relationKey)
     {
-        if (!method_exists($model, $relationKey)) {
-            throw new Exception(
-                    'Relation "' . $relationKey . '" does not exist in model',
-                    static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
-                    BaseResponse::HTTP_INTERNAL_SERVER_ERROR
-                );
-        }
+        // Explicitly NOT checking if method_exists($model, $relationKey),
+        // since that prevents these things from being handled dynamically
+        // by __call.
         
         $relationModels = $model->{$relationKey};
         if (is_null($relationModels)) {


### PR DESCRIPTION
in Handler::getModelsForRelation and add a comment explaining why the check isn't there.

Similar to my previous pull request, I think it'd make sense to make this 5.0.2 and also merge with the 6.x changes to make 6.0.2.
